### PR TITLE
Fixed a bug, and updated for the current node.js(0.8.*)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,12 @@
 		"email": "vjeuxx@gmail.com",
 		"url": "http://blog.vjeux.com/"
 	},
+	"contributors": [
+		{
+			"name": "HANAI Tohru",
+			"email": "hanai@pokelabo.co.jp"
+		}
+	],
 	"homepage": "http://blog.vjeux.com/",
 	"files" : [
 		"src/handlers.coffee",

--- a/src/optparse.coffee
+++ b/src/optparse.coffee
@@ -27,7 +27,11 @@ exports.OptionParser = class OptionParser
     options = arguments: [], literals: []
     originalArgs = args
     args = normalizeArguments args
+    isOptionArgument = false
     for arg, i in args
+      if isOptionArgument
+        isOptionArgument = false
+        continue
       if arg is '--'
         pos = originalArgs.indexOf '--'
         options.arguments = [originalArgs[1 + pos]]
@@ -40,6 +44,7 @@ exports.OptionParser = class OptionParser
           value = if rule.hasArgument then args[i += 1] else true
           options[rule.name] = if rule.isList then (options[rule.name] or []).concat value else value
           matchedRule = yes
+          isOptionArgument = rule.hasArgument
           break
       throw new Error "unrecognized option: #{arg}" if isOption and not matchedRule
       if not isOption

--- a/src/watcher.coffee
+++ b/src/watcher.coffee
@@ -202,7 +202,7 @@ removeSource = (source, base, removeJs) ->
 	sourceCode.splice index, 1
 	if removeJs and not opts.join
 		jsPath = outputPath source, base
-		path.exists jsPath, (exists) ->
+		fs.exists jsPath, (exists) ->
 			if exists
 				fs.unlink jsPath, (err) ->
 					throw err if err and err.code isnt 'ENOENT'
@@ -226,7 +226,7 @@ writeJs = (source, js, base) ->
 	compile = ->
 		handlers[ext] js, source, jsPath
 		timeLog "compiled #{source}"
-	path.exists jsDir, (exists) ->
+	fs.exists jsDir, (exists) ->
 		if exists then compile() else exec "mkdir -p #{jsDir}", compile
 
 # Convenience for cleaner setTimeouts.


### PR DESCRIPTION
The bug was it doubly/unexpected files compiled with `--output` option. 
It happened because optparse did include the last option's argument as
one of `arguments`.
Then if the output directory was ancestor of source directory, it compiled
doubly into the same directory of sources.
And if the output directory and descendants included compilation targets,
it compiled them, too.

One more modification, path.exists -> fs.exists, followed the api update
since Node.js 0.7.1.
