### PR TITLE
Fix a bug; output to wrong directory with sources argument './'

### DIFF
--- a/src/watcher.coffee
+++ b/src/watcher.coffee
@@ -255,7 +255,7 @@ parseOptions = ->
 	o.compile     or=  !!o.output
 	o.run         = not (o.compile or o.print or o.lint)
 	o.print       = !!  (o.print or (o.eval or o.stdio and o.compile))
-	sources       = o.arguments
+	sources = (source.replace /(.)\/+$/, '$1' for source in o.arguments)
 	sourceCode[i] = null for source, i in sources
 	return
 


### PR DESCRIPTION
Hi, here's one more fix. :)

If you have source directory as following;
  foo/
  foo/src/
  foo/src/lib/app.js
and executed watcher with `watcher -o ../ ./` in the directory `foo/src`,
watcher wrongthy did output `app.js` into `foo/b/` directory.
